### PR TITLE
Bump checkout to v5 in workflows

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_COMMIT_TOKEN }}
 

--- a/.github/workflows/update-featured-repo.yml
+++ b/.github/workflows/update-featured-repo.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: jamesgeorge007/github-activity-readme@master
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump every workflow checkout step to `actions/checkout@v5`.
- Clear the Node 20 deprecation warning emitted by the hosted runner.

## Changes
- Updated `github-stats.yml`, `update-readme.yml`, and `update-featured-repo.yml` to use `actions/checkout@v5`.
- Kept the rest of the workflow logic unchanged.

## Evidence
- `GitHub Stats Update` failed on 2026-04-25T02:21:35Z with `fatal: could not read Username for 'https://github.com': terminal prompts disabled`.
- The same log also warned that `actions/checkout@v4` is running on Node.js 20 and will need an upgrade.
- Later scheduled runs in the same repo were green, so this is a maintenance hardening change rather than a behavior fix.

## Testing
- `git diff --check`
- Repository pre-commit workflow tests