### PR TITLE
Pin README activity workflow to v0.5.0

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -12,6 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: jamesgeorge007/github-activity-readme@master
+      - uses: jamesgeorge007/github-activity-readme@v0.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin the README activity workflow to the released `jamesgeorge007/github-activity-readme` tag `v0.5.0` instead of tracking `master`.
- Reduce supply-chain drift risk without changing the workflow behavior.

## Changes
- Updated `.github/workflows/update-readme.yml` to use `jamesgeorge007/github-activity-readme@v0.5.0`.

## Testing
- `git diff --check`
- Repo pre-commit profile test suite
