### PR TITLE
Use github.token fallback for stats workflow

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.GH_COMMIT_TOKEN }}
+          token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
         uses: VatsalSy/commits-readme-stats@v4.0
         with:
-          GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN }}
+          GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true
           SHOW_DAYS_OF_WEEK: true
           # WakaTime integration


### PR DESCRIPTION
## Summary
- Make GitHub stats workflow resilient to missing `GH_COMMIT_TOKEN` by falling back to `github.token`.

## Changes
- Update `.github/workflows/github-stats.yml` checkout auth token to `secrets.GH_COMMIT_TOKEN || github.token`.
- Update `VatsalSy/commits-readme-stats` action input `GH_COMMIT_TOKEN` with the same fallback.

## Testing
- Local pre-commit tests were executed via repo hooks during commit and passed.
