### PR TITLE
Ship bounded profile commit counter

### DIFF
--- a/.github/test/workflow-schedules.json
+++ b/.github/test/workflow-schedules.json
@@ -2,7 +2,7 @@
   "expectedSchedules": {
     "update-featured-repo.yml": "30 */6 * * *",
     "ReadmeWaka.yml": "0 */4 * * *",
-    "github-stats.yml": "0 */4 * * *",
+    "github-stats.yml": "0 3 * * *",
     "my-badges.yml": "0 0 * * *",
     "update-readme.yml": "10 */4 * * *"
   }

--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -1,7 +1,7 @@
 name: GitHub Stats Update
 on:
   schedule:
-    - cron: '0 3 * * *'  # Complete branch-history crawl once daily
+    - cron: '0 3 * * *'  # Complete default-branch crawl once daily
   workflow_dispatch:      # Allows manual trigger
 
 concurrency:
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   update-stats:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
-        uses: VatsalSy/commits-readme-stats@c99b9539ba435cd29c66f7084264bc9c47e7af84
+        uses: VatsalSy/commits-readme-stats@1265d88aecad9b64cde7bbf48b5752e02942aaf6
         with:
           GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ This is a GitHub profile README repository for Vatsal Sanjay, a fluid dynamicist
 The repository uses several automated workflows that run on schedule:
 
 ### 1. GitHub Stats Update (`.github/workflows/github-stats.yml`)
-- **Schedule**: Every 4 hours
-- **Purpose**: Updates commit statistics and activity metrics in README
+- **Schedule**: Daily at 03:00 UTC
+- **Purpose**: Updates bounded default-branch commit statistics in README
 - **Manual trigger**: Available via workflow_dispatch
 
 ### 2. My Badges (`.github/workflows/my-badges.yml`)
@@ -24,7 +24,7 @@ The repository uses several automated workflows that run on schedule:
 - **Command**: `npx update-my-badges`
 
 ### 3. GitHub Stats and WakaTime (`.github/workflows/github-stats.yml`)
-- **Schedule**: Every 4 hours
+- **Schedule**: Daily at 03:00 UTC
 - **Purpose**: Updates commit statistics and WakaTime metrics in the README
 - **Manual trigger**: Available via workflow_dispatch
 - **Dependencies**: Uses `WAKATIME_API_KEY` (secret key) when WakaTime output is enabled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ This is a GitHub profile README repository for Vatsal Sanjay, a fluid dynamicist
 The repository uses several automated workflows that run on schedule:
 
 ### 1. GitHub Stats Update (`.github/workflows/github-stats.yml`)
-- **Schedule**: Every 4 hours
-- **Purpose**: Updates commit statistics and activity metrics in README
+- **Schedule**: Daily at 03:00 UTC
+- **Purpose**: Updates bounded default-branch commit statistics in README
 - **Manual trigger**: Available via workflow_dispatch
 
 ### 2. My Badges (`.github/workflows/my-badges.yml`)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Sunday                   1272 commits        ████░░░░░░░�
 
 <!--END_SECTION:github-stats-->
 
-<sub>GitHub's contribution total includes public/default-branch commits, private or restricted activity, issues, pull requests, reviews, and repository creation. The commit figure above is a separate crawl of unique authored Git objects reachable through currently accessible branches, so the two totals are intentionally not equal.</sub>
+<sub>GitHub's contribution calendar counts events, not commits: public/default-branch commits, private or restricted activity, issues, pull requests, reviews, and repository creation. The custom total above counts globally deduplicated, primary-authored Git objects reachable from default branches visible to the action token at its last successful crawl; inaccessible repositories, topic-branch-only commits, unlinked authors, and rewritten history are excluded.</sub>
 
 </details>
 


### PR DESCRIPTION
## Summary
- pin the merged, audited default-branch counter revision
- cap the workflow at 60 minutes and keep the daily 03:00 UTC schedule
- fix the stale schedule fixture and repository guidance
- explain precisely why GitHub contribution events and the custom commit metric differ

## Evidence
- action PR #104 is merged with 53 tests and security checks passing
- all profile workflow, schedule, permission, secret, and README tests pass
- the old exhaustive all-branch run reproduced GitHub secondary limiting after 24 of 357 repositories