### PR TITLE
Pin large-history fallback

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
-        uses: VatsalSy/commits-readme-stats@1265d88aecad9b64cde7bbf48b5752e02942aaf6
+        uses: VatsalSy/commits-readme-stats@fb000ae8448edc4f10338b3a12cbd9cae8041606
         with:
           GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true


### PR DESCRIPTION
Pin the audited action revision from commits-readme-stats PR #105. The previous live run was safely aborted when comphy-lab/basilisk-C returned persistent HTTP 502 responses; this revision retains the normal fast path and partitions only persistent 5xx histories into bounded yearly windows. Profile tests pass.