### PR TITLE
Pin lean commit history query

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
-        uses: VatsalSy/commits-readme-stats@fb000ae8448edc4f10338b3a12cbd9cae8041606
+        uses: VatsalSy/commits-readme-stats@ddd89d3040cf16364bdbc874b41218474841b2e1
         with:
           GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true


### PR DESCRIPTION
Pin commits-readme-stats PR #106. The previous run proved that unused additions/deletions fields caused GitHub to time out on basilisk-C; the same complete history query with only OID, timestamp, and linked author returns immediately. Profile workflow tests pass.