### PR TITLE
Pin reviewed commit fallback fix

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
-        uses: VatsalSy/commits-readme-stats@ddd89d3040cf16364bdbc874b41218474841b2e1
+        uses: VatsalSy/commits-readme-stats@58b0a5302a10fa4d1dde10715094c0ac7c9c4b54
         with:
           GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true


### PR DESCRIPTION
## Summary
- pin the commit counter workflow to reviewed action commit `58b0a5302a10fa4d1dde10715094c0ac7c9c4b54`
- ensure persistent 502/503/504 responses retain their status and trigger bounded yearly fallback

## Evidence
- action PR VatsalSy/commits-readme-stats#107 passed both security checks and Codex review
- local profile test suite passed: 2 suites, 11 assertions, 0 failures