### PR TITLE
Schedule commit crawl at 03:17 UTC

### DIFF
--- a/.github/test/workflow-schedules.json
+++ b/.github/test/workflow-schedules.json
@@ -2,7 +2,7 @@
   "expectedSchedules": {
     "update-featured-repo.yml": "30 */6 * * *",
     "ReadmeWaka.yml": "0 */4 * * *",
-    "github-stats.yml": "0 3 * * *",
+    "github-stats.yml": "17 3 * * *",
     "my-badges.yml": "0 0 * * *",
     "update-readme.yml": "10 */4 * * *"
   }

--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -1,7 +1,7 @@
 name: GitHub Stats Update
 on:
   schedule:
-    - cron: '0 3 * * *'  # Complete default-branch crawl once daily
+    - cron: '17 3 * * *'  # Complete default-branch crawl daily at 03:17 UTC
   workflow_dispatch:      # Allows manual trigger
 
 concurrency:
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
 
       - name: Generate Stats
-        uses: VatsalSy/commits-readme-stats@58b0a5302a10fa4d1dde10715094c0ac7c9c4b54
+        uses: VatsalSy/commits-readme-stats@46fcfb462c8bb0615685721fd395656e1b4928b9
         with:
           GH_COMMIT_TOKEN: ${{ secrets.GH_COMMIT_TOKEN || github.token }}
           SHOW_COMMIT: true


### PR DESCRIPTION
## What changed

- moves the daily commit-statistics crawl from 03:00 to 03:17 UTC
- pins the workflow to the timestamp-aware action revision from VatsalSy/commits-readme-stats#108
- updates the schedule regression fixture

## Why

GitHub warns that scheduled workflows near the top of the hour are more likely to be delayed. The profile will also now show the UTC date and time of its last successful full crawl.

## Validation

- `cd .github/test && npm test` — all profile suites passed
- `git diff --check`